### PR TITLE
feat: add C++ example to parse simulated COBS-encoded protobuf data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ __pycache__
 .pytest_cache
 .vscode/
 release/
+/build/
+/*.exe
+/*.obj
+/*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.15)
+project(rscp_cpp_example)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# Protobuf Settings
+find_package(Protobuf REQUIRED)
+find_package(absl CONFIG REQUIRED)
+
+# Uncomment only if necessary (for Dynamic Linking Errors)
+#set(Protobuf_LIBRARIES "<libprotobuf.lib-path>")
+
+
+include_directories(
+    ${Protobuf_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/examples/Cpp
+    ${CMAKE_SOURCE_DIR}/examples/Cpp/Include
+    ${CMAKE_SOURCE_DIR}/examples/Cpp/proto
+)
+
+add_executable(receive_commands_noserial
+    examples/Cpp/receive_commands_noserial.cpp
+    examples/Cpp/proto/rscp.pb.cc
+)
+
+target_compile_definitions(receive_commands_noserial PRIVATE blurb)
+
+
+target_link_libraries(receive_commands_noserial
+    ${Protobuf_LIBRARIES}
+    absl::base
+    absl::log_internal_check_op
+    absl::log_severity
+    absl::strings
+)
+# Protobuf Lib Path Debug
+message(STATUS "Protobuf libs: ${Protobuf_LIBRARIES}")
+

--- a/examples/Cpp/Include/cobs.h
+++ b/examples/Cpp/Include/cobs.h
@@ -1,0 +1,50 @@
+#ifndef COBS_H
+#define COBS_H
+
+#include <vector>
+#include <cstdint>
+#include <cstddef>
+
+/**
+ * @brief Decodes data encoded with Consistent Overhead Byte Stuffing (COBS).
+ * 
+ * This function takes a buffer of bytes that has been encoded using the COBS
+ * algorithm and reconstructs the original data by removing the added overhead
+ * bytes and restoring zero delimiters.
+ *
+ * @param input  Pointer to the COBS-encoded byte buffer.
+ * @param length Length of the input buffer.
+ * @return std::vector<uint8_t> Decoded byte buffer.
+ *
+ * @note If the encoded input is malformed (e.g., code byte is 0 or exceeds bounds),
+ *       decoding will stop prematurely.
+ */
+std::vector<uint8_t> cobs_decode(const uint8_t* input, size_t length) {
+    std::vector<uint8_t> output;
+    output.reserve(length);  // Reserve enough space for the decoded data
+
+    size_t index = 0;
+    while (index < length) {
+        uint8_t code = input[index];
+
+        // Stop decoding on invalid code byte or if bounds are exceeded
+        if (code == 0 || index + code > length + 1)
+            break;
+
+        // Copy the next (code - 1) bytes as literal data
+        for (uint8_t i = 1; i < code; ++i) {
+            output.push_back(input[index + i]);
+        }
+
+        // Append a zero byte if the code is not 0xFF (which means no zero was encoded)
+        if (code != 0xFF && index + code < length) {
+            output.push_back(0);
+        }
+
+        index += code;
+    }
+
+    return output;
+}
+
+#endif // COBS_H

--- a/examples/Cpp/receive_commands_noserial.cpp
+++ b/examples/Cpp/receive_commands_noserial.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include "rscp.pb.h"      // Generated protobuf header
+#include "Include\cobs.h" // COBS (Consistent Overhead Byte Stuffing) encoding/decoding
+
+/**
+ * @brief Callback function to handle and decode incoming COBS-encoded protobuf messages.
+ *
+ * This function takes a byte buffer representing a COBS-encoded Protocol Buffers message,
+ * decodes it using the COBS algorithm, and attempts to deserialize it into a
+ * `rscp::RequestEnvelope` object. If successful, it prints out the request type and
+ * a full debug string of the message contents.
+ *
+ * @param buffer A reference to a vector of bytes representing the received data frame.
+ *
+ * @note If decoding or parsing fails, an error message is printed to stderr.
+ */
+void on_receive(const std::vector<uint8_t> &buffer)
+{
+    // Decode the received buffer using COBS
+    auto decoded = cobs_decode(buffer.data(), buffer.size());
+
+    // Deserialize the protobuf message into a RequestEnvelope object
+    rscp::RequestEnvelope request;
+    if (!request.ParseFromArray(decoded.data(), decoded.size()))
+    {
+        std::cerr << "Failed to parse cmakprotobuf message.\n";
+        return;
+    }
+
+    // Log the received request type and full debug output
+    std::cout << "Received Request type: " << request.request_case() << std::endl;
+    std::cout << request.DebugString() << std::endl;
+}
+
+/**
+ * main function
+ */
+int main()
+{
+    rscp::RequestEnvelope request;
+
+    // Simulated raw COBS-encoded data stream (might represent multiple frames)
+    std::vector<uint8_t> simulated_data = {
+        0x05, 0x0A, 0x02, 0x08, 0x01, 0x00, 0x05, 0x12, 0x02, 0x08, 0x03, 0x00, 0x1C, 0x1A, 0x19, 0x0A, 0x17,
+        0x09, 0x58, 0x39, 0xB4, 0xC8, 0x76, 0xBE, 0xF3, 0x3F, 0x11, 0x83, 0xC0, 0xCA, 0xA1, 0x45, 0xB6, 0x16,
+        0x40, 0x1D, 0xA1, 0xD6, 0x7C, 0x3F, 0x00, 0x18, 0x22, 0x19, 0x0A, 0x12, 0x09, 0x58, 0x39, 0xB4, 0xC8,
+        0x76, 0xBE, 0xF3, 0x3F, 0x11, 0x83, 0xC0, 0xCA, 0xA1, 0x45, 0xB6, 0x16, 0x40, 0x15, 0x01, 0x03, 0xC8,
+        0x42, 0x00,0x02, 0x2A, 0x01, 0x00};
+
+    std::vector<uint8_t> buffer;
+
+    // Split the stream into frames using 0x00 as a frame delimiter
+    for (auto byte : simulated_data)
+    {
+        if (byte == 0x00)
+        {
+            // Process the complete frame
+            on_receive(buffer);
+            buffer.clear();
+        }
+        else
+        {
+            // Accumulate bytes into the current frame
+            buffer.push_back(byte);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
- Implements a C++ example that decodes COBS-encoded binary frames
- Parses messages into rscp::RequestEnvelope using Protocol Buffers
- Includes simulated data stream for testing
- Adds helper function for COBS decoding