### PR TITLE
add: dummy field added to proto file for empty message parse issue

### DIFF
--- a/.github/workflows/build_protobuf.yml
+++ b/.github/workflows/build_protobuf.yml
@@ -31,6 +31,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "28.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install protobuf-c compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-c-compiler
       - name: Install pip dependencies

--- a/proto/rscp.proto
+++ b/proto/rscp.proto
@@ -77,7 +77,9 @@ message SetStage {
 /**
  * Start exploration.
  */
-message StartExploration {}
+message StartExploration {
+  bool dummy_field = 1;
+}
 
 /**
  * Envelope for all request messages.

--- a/proto/rscp.proto
+++ b/proto/rscp.proto
@@ -49,7 +49,9 @@ enum RoverState {
  * Arm or disarm the rover.
  */
 message ArmDisarm {
-  optional bool value = 1; // True to arm, false to disarm.
+    oneof value_wrapper { // True to arm, false to disarm.
+    bool value = 1;
+  }
 }
 
 /**

--- a/proto/rscp.proto
+++ b/proto/rscp.proto
@@ -49,7 +49,7 @@ enum RoverState {
  * Arm or disarm the rover.
  */
 message ArmDisarm {
-  bool value = 1; // True to arm, false to disarm.
+  optional bool value = 1; // True to arm, false to disarm.
 }
 
 /**


### PR DESCRIPTION
## Protobuf Empty Message Issue Fix
- Without the dummy_field, StartExploration was treated as an empty message, causing serialization and parsing issues in some environments. This field ensures the message is valid and can be reliably transmitted using protobuf.
